### PR TITLE
Fix: VM 정보 메모리 단위(MB -> GB) 수정

### DIFF
--- a/src/proxmox/rest/handler.go
+++ b/src/proxmox/rest/handler.go
@@ -252,10 +252,10 @@ func processVMData(data interface{}, userId string, h *Handler) ([]interface{}, 
 		maxdisk := fmt.Sprintf("%.2f", vmMap["maxdisk"].(float64)/(1024*1024*1024)) // GB
 		vmMap["maxdisk"] = maxdisk
 
-		maxmem := fmt.Sprintf("%.2f", vmMap["maxmem"].(float64)/(1024*1024)) // MB
+		maxmem := fmt.Sprintf("%.2f", vmMap["maxmem"].(float64)/(1024*1024*1024)) // GB
 		vmMap["maxmem"] = maxmem
 
-		mem := fmt.Sprintf("%.2f", vmMap["mem"].(float64)/(1024*1024)) // MB
+		mem := fmt.Sprintf("%.2f", vmMap["mem"].(float64)/(1024*1024*1024)) // GB
 		vmMap["mem"] = mem
 
 		cpu := int(vmMap["cpus"].(float64))


### PR DESCRIPTION
processVMData 함수
- 데이터 처리 시 VM 정보의 메모리 단위 MB -> GB로 수정