### PR TITLE
Fix: https 코드 삭제

### DIFF
--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -4,12 +4,11 @@ import (
 	proxmox_rest "hyperdesk/proxmox/rest"
 	user_rest "hyperdesk/user/rest"
 	vm_rest "hyperdesk/vm/rest"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-func Run(address string) (chan error, error) {
+func Run(address string) error {
 	router := gin.Default()
 
 	v1 := router.Group("/api/user")
@@ -21,8 +20,5 @@ func Run(address string) (chan error, error) {
 	v3 := router.Group("/api/proxmox")
 	proxmox_rest.ProxmoxRoutes(v3)
 
-	httpsErrChan := make(chan error)
-	go func() { httpsErrChan <- http.ListenAndServeTLS(address, "cert.pem", "key.pem", router) }()
-
-	return httpsErrChan, router.Run(address)
+	return router.Run(address)
 }


### PR DESCRIPTION
- https 코드 삭제: routes.go에서 ListenAndServeTLS() 메소드 삭제