### PR TITLE
[Fix] proxmox proxy에 proxmoxId 정보 추가

### DIFF
--- a/src/proxmox/dblayer/orm.go
+++ b/src/proxmox/dblayer/orm.go
@@ -6,10 +6,11 @@ import (
 
 	"hyperdesk/database"
 	"hyperdesk/proxmox/models"
+
+	"github.com/go-errors/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"github.com/go-errors/errors"
 )
 
 type ORM struct {
@@ -41,8 +42,9 @@ func (orm *ORM) InsertProxy(proxy models.Proxy) (*mongo.UpdateResult, error) {
 	filter := bson.M{"userId": proxy.UserId}
 	update := bson.M{
 		"$set": bson.M{
-			"address": proxy.Address,
-			"port":    proxy.Port,
+			"address":   proxy.Address,
+			"port":      proxy.Port,
+			"proxmoxId": proxy.ProxmoxId,
 		},
 	}
 

--- a/src/proxmox/models/model.go
+++ b/src/proxmox/models/model.go
@@ -17,9 +17,10 @@ type ProxmoxToken struct {
 
 // Proxy는 사용자와 관련된 프록시 정보를 정의합니다.
 type Proxy struct {
-	UserId  string `json:"userId" bson:"userId"`
-	Address string `json:"address" bson:"address"`
-	Port    string `json:"port" bson:"port"`
+	UserId    string `json:"userId" bson:"userId"`
+	Address   string `json:"address" bson:"address"`
+	Port      string `json:"port" bson:"port"`
+	ProxmoxId string `json:"proxmoxId" bson:"proxmoxId"`
 }
 
 // TokenClaims는 JWT 토큰의 클레임을 정의합니다.

--- a/src/proxmox/rest/handler.go
+++ b/src/proxmox/rest/handler.go
@@ -67,9 +67,10 @@ func (h *Handler) TokenHandler(c *gin.Context) {
 	}
 
 	proxy := models.Proxy{
-		UserId:  userId,
-		Address: creds.Address,
-		Port:    creds.Port,
+		UserId:    userId,
+		Address:   creds.Address,
+		Port:      creds.Port,
+		ProxmoxId: creds.UserId,
 	}
 
 	_, err = h.proxmoxdbLayer.InsertProxy(proxy)


### PR DESCRIPTION
### PR 타입 
 - [ ] 기능 추가
 - [ ] 기능 삭제
 - [x] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 🌵
fix/proxmox-proxy ➡️ main

### 작업사항 📝
- proxmox proxy 구조체에 proxmoxId 정보 추가
- mongoDB에 proxmoxId 정보도 추가로 저장
- proxy 정보 조회 시 proxmoxId도 추가로 반환

### 신규 API 목록 ✅


### 테스트 방법 🔎


### 관련 이슈 💡

